### PR TITLE
[FIX] Detect labels only based on their name, not their description

### DIFF
--- a/.github/workflows/manual_label_population_to_repos.yml
+++ b/.github/workflows/manual_label_population_to_repos.yml
@@ -100,7 +100,7 @@ jobs:
             echo -e "\nSyncing label ${{matrix.label}} to ${repo}!"
             
             # We escape grep's nonzero exit status here
-            out=$(gh label list -R "${repo}" -L 100 | grep -w "${{ matrix.label }}" || echo "")
+            out=$(gh label list -R "${repo}" -L 100 | cut -f 1 | grep -w "${{ matrix.label }}" || echo "")
             
             if [ -z "${out}" ]; then
               # Label missing


### PR DESCRIPTION
Apply @alyssadai suggestion for not breaking the workflow by only reading the label name and not the description

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #98 
With many thanks to @alyssadai 
<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

-
-

<!-- To be checked off by reviewers -->
## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
